### PR TITLE
Support multiple certificates [breaking change]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## v2.0.0
+
+#### Breaking Changes:
+
+- Support multiple certificates: Removed `X509Certificate` string in favor of `X509Certificates` array 
+
+---
+
+## v1.0.0
+
+_No changelog for this release._

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ console.log(metadata)
   Output:
   {
     entityId: 'https://sts.windows.net/12345678-1234-1234-1234-123456789012/',
-    X509Certificate: 'example-cert',
+    X509Certificates: ['example-cert'],
     HTTPRedirect: 'https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/saml2',
     HTTPPost: 'https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/saml2'
   }
@@ -44,7 +44,7 @@ console.log(metadata)
   Output:
   {
     entityId: 'https://sts.windows.net/12345678-1234-1234-1234-123456789012/',
-    X509Certificate: 'example-cert',
+    X509Certificates: ['example-cert'],
     HTTPRedirect: 'https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/saml2',
     HTTPPost: 'https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/saml2'
   }

--- a/lib/parseIDPMetadata.js
+++ b/lib/parseIDPMetadata.js
@@ -5,14 +5,14 @@ const parseIDPMetadata = async (data) => {
 
   const entityDescriptor = mdGet(data, 'EntityDescriptor')
   const IDPSSODescriptor = mdGet(entityDescriptor, 'IDPSSODescriptor.0')
-  const keyDescriptor = mdGet(IDPSSODescriptor, 'KeyDescriptor.0')
+  const keyDescriptors = mdGet(IDPSSODescriptor, 'KeyDescriptor')
   const singleSignOnServices = mdGet(IDPSSODescriptor, 'SingleSignOnService')
 
-  const X509Certificate = (
+  const X509Certificates = keyDescriptors.map(keyDescriptor => (
     get(keyDescriptor, 'KeyInfo.0.X509Data.0.X509Certificate.0') ||
     get(keyDescriptor, 'ds:KeyInfo.0.ds:X509Data.0.ds:X509Certificate.0') ||
     get(keyDescriptor, 'dsig:KeyInfo.0.dsig:X509Data.0.dsig:X509Certificate.0')
-  )
+  ))
   const entityId = get(entityDescriptor, '$.entityID')
   const [HTTPRedirect] = singleSignOnServices
     .map(obj => obj.$)
@@ -25,7 +25,7 @@ const parseIDPMetadata = async (data) => {
 
   return {
     entityId,
-    X509Certificate,
+    X509Certificates,
     HTTPRedirect,
     HTTPPost
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata-saml2",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Parse SAML metadata.xml files",
   "main": "index.js",
   "license": "MIT",

--- a/tests/identity-providers/google/index.test.js
+++ b/tests/identity-providers/google/index.test.js
@@ -2,15 +2,28 @@ const { parseIDPMetadataFromFile } = require('../../../index')
 const path = require('path')
 
 describe('Google', () => {
-  const filePath = path.join(__dirname, './metadata.xml')
-
   it('should parse metadata.xml', async () => {
+    const filePath = path.join(__dirname, './metadata.xml')
     const result = await parseIDPMetadataFromFile(filePath)
     expect(result).toEqual({
       entityId: 'https://accounts.google.com/o/saml2?idpid=C02abcdef',
       HTTPPost: 'https://accounts.google.com/o/saml2/idp?idpid=C02abcdef',
       HTTPRedirect: 'https://accounts.google.com/o/saml2/idp?idpid=C02abcdef',
-      X509Certificate: 'example-cert'
+      X509Certificates: ['example-cert']
+    })
+  })
+
+  it('should parse metadata-multi-cert.xml and return two certificates', async () => {
+    const filePath = path.join(__dirname, './metadata-multi-cert.xml')
+    const result = await parseIDPMetadataFromFile(filePath)
+    expect(result).toEqual({
+      entityId: 'https://accounts.google.com/o/saml2?idpid=C02abcdef',
+      HTTPPost: 'https://accounts.google.com/o/saml2/idp?idpid=C02abcdef',
+      HTTPRedirect: 'https://accounts.google.com/o/saml2/idp?idpid=C02abcdef',
+      X509Certificates: [
+        'example-cert-1',
+        'example-cert-2'
+      ]
     })
   })
 })

--- a/tests/identity-providers/google/metadata-multi-cert.xml
+++ b/tests/identity-providers/google/metadata-multi-cert.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://accounts.google.com/o/saml2?idpid=C02abcdef" validUntil="2023-01-11T17:57:17.000Z">
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>example-cert-1</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>example-cert-2</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://accounts.google.com/o/saml2/idp?idpid=C02abcdef"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://accounts.google.com/o/saml2/idp?idpid=C02abcdef"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>

--- a/tests/identity-providers/jumpcloud/index.test.js
+++ b/tests/identity-providers/jumpcloud/index.test.js
@@ -10,7 +10,7 @@ describe('JumpCloud', () => {
       entityId: 'https://api.acme.com/saml',
       HTTPPost: 'https://sso.jumpcloud.com/saml2/acme',
       HTTPRedirect: undefined,
-      X509Certificate: 'example-cert'
+      X509Certificates: ['example-cert']
     })
   })
 })

--- a/tests/identity-providers/keycloak/index.test.js
+++ b/tests/identity-providers/keycloak/index.test.js
@@ -10,7 +10,7 @@ describe('Keycloak', () => {
       entityId: 'https://sso.acme.com/auth/realms/ACME-SSO',
       HTTPPost: 'https://sso.acme.com/auth/realms/ACME-SSO/protocol/saml',
       HTTPRedirect: undefined,
-      X509Certificate: 'example-cert'
+      X509Certificates: ['example-cert']
     })
   })
 })

--- a/tests/identity-providers/microsoft/index.test.js
+++ b/tests/identity-providers/microsoft/index.test.js
@@ -10,7 +10,7 @@ describe('Microsoft', () => {
       entityId: 'https://sts.windows.net/12345678-1234-1234-1234-123456789012/',
       HTTPPost: 'https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/saml2',
       HTTPRedirect: 'https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/saml2',
-      X509Certificate: 'example-cert'
+      X509Certificates: ['example-cert']
     })
   })
 })

--- a/tests/identity-providers/okta/index.test.js
+++ b/tests/identity-providers/okta/index.test.js
@@ -9,7 +9,7 @@ describe('Okta', () => {
       entityId: 'http://www.okta.com/exkgtqmzpeABC1234567',
       HTTPPost: 'https://acme.okta.com/app/example_saml/exkgtqmzpeABC1234567/sso/saml',
       HTTPRedirect: 'https://acme.okta.com/app/example_saml/exkgtqmzpeABC1234567/sso/saml',
-      X509Certificate: 'example-cert'
+      X509Certificates: ['example-cert']
     })
   })
 
@@ -20,7 +20,7 @@ describe('Okta', () => {
       entityId: 'http://www.okta.com/10203040501020304050',
       HTTPPost: 'https://acme.okta.com/app/example_saml/10203040501020304050/sso/saml',
       HTTPRedirect: 'https://acme.okta.com/app/example_saml/10203040501020304050/sso/saml',
-      X509Certificate: 'example-cert'
+      X509Certificates: ['example-cert']
     })
   })
 })

--- a/tests/identity-providers/onelogin/index.test.js
+++ b/tests/identity-providers/onelogin/index.test.js
@@ -10,7 +10,7 @@ describe('Onelogin', () => {
       entityId: 'https://app.onelogin.com/saml/metadata/12345678-1234-1234-1234-123456789012',
       HTTPPost: 'https://acme.onelogin.com/trust/saml2/http-post/sso/12345678-1234-1234-1234-123456789012',
       HTTPRedirect: 'https://acme.onelogin.com/trust/saml2/http-redirect/sso/12345678-1234-1234-1234-123456789012',
-      X509Certificate: 'example-cert'
+      X509Certificates: ['example-cert']
     })
   })
 })


### PR DESCRIPTION
Breaking change
- Return `X509Certificates` array instead of a single `X509Certificate` string
- Update unit tests
- Updated readme
- Added changelog
- Bumped major version (2.0.0)